### PR TITLE
Bugfix suspended state sync loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ class ProtomuxRpcClient extends ReadyResource {
 
     while (!this.rpc && !this.closing) {
       await this.connect()
-      if (this._suspended !== null) await this._suspended
+      if (this.suspended) await this._suspendedProm
     }
 
     if (this.closing) return


### PR DESCRIPTION
`_suspended` and `_suspend` aren't defined (so both `undefined`), and in some cases this ended up being a sync loop