### PR TITLE
Support protomux's id and protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Options:
 
 ```
 {
-  requestEncoding, // Used to encode the `args`. Default: `c.buffer`
-  responseEncoding, // Used to decode the response
+  requestEncoding, // Used to encode the `args`. Default: the protomux-rpc default.
+  responseEncoding, // Used to decode the response. Default: the protomux-rpc default.
   id, // id of the protomux-rpc service
   protocol, // protocol of the protomux-rpc service. Defaults to the server's public key.
   timeout // time (in ms) before a request rejects with a timeout error. Defaults to the requestTimeout.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Options:
 {
   requestEncoding, // Used to encode the `args`. Default: `c.buffer`
   responseEncoding, // Used to decode the response
+  id, // id of the protomux-rpc service
+  protocol, // protocol of the protomux-rpc service. Defaults to the server's public key.
   timeout // time (in ms) before a request rejects with a timeout error. Defaults to the requestTimeout.
 }
 ```

--- a/example.js
+++ b/example.js
@@ -35,7 +35,7 @@ async function main () {
     console.log('server opened connection')
     const rpc = new ProtomuxRPC(c, {
       id: serverPubKey,
-      valueEncoding: c.none
+      valueEncoding: cenc.none
     })
     rpc.respond(
       'echo',

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ const waitForRPC = require('./wait-for-rpc.js')
 const Errors = require('./errors.js')
 
 class ProtomuxRpcConnection extends SuspendResource {
-  constructor (serverKey, dht, { backoffValues, keyPair = null, suspended = false, relayThrough = null } = {}) {
+  constructor (serverKey, dht, { backoffValues, keyPair = null, suspended = false, relayThrough = null, id = null, protocol = undefined } = {}) {
     super({ suspended })
 
     this.serverKey = HypercoreId.decode(serverKey)
@@ -20,6 +20,9 @@ class ProtomuxRpcConnection extends SuspendResource {
     this.keyPair = keyPair
     this.relayThrough = relayThrough
     this.backoffValues = backoffValues
+
+    this.id = id || this.serverKey
+    this.protocol = protocol
 
     this._connecting = null
     this._backoff = new Backoff(this.backoffValues)
@@ -86,9 +89,9 @@ class ProtomuxRpcConnection extends SuspendResource {
       if (this.dht.destroyed) return
 
       const socket = this.dht.connect(this.serverKey, { keyPair: this.keyPair, relayThrough: this.relayThrough })
-
       const rpc = new ProtomuxRPC(socket, {
-        id: this.serverKey,
+        id: this.id,
+        protocol: this.protocol,
         valueEncoding: c.none
       })
       rpc.once('close', () => socket.destroy())

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 const ProtomuxRPC = require('protomux-rpc')
-const c = require('compact-encoding')
+const cenc = require('compact-encoding')
 const HypercoreId = require('hypercore-id-encoding')
 const SuspendResource = require('suspend-resource')
 const safetyCatch = require('safety-catch')
@@ -92,7 +92,7 @@ class ProtomuxRpcConnection extends SuspendResource {
       const rpc = new ProtomuxRPC(socket, {
         id: this.id,
         protocol: this.protocol,
-        valueEncoding: c.none
+        valueEncoding: cenc.none
       })
       rpc.once('close', () => socket.destroy())
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,7 +10,7 @@ const waitForRPC = require('./wait-for-rpc.js')
 const Errors = require('./errors.js')
 
 class ProtomuxRpcConnection extends SuspendResource {
-  constructor (serverKey, dht, { backoffValues, keyPair = null, suspended = false, relayThrough = null, id = null, protocol = undefined } = {}) {
+  constructor (serverKey, dht, { backoffValues, keyPair = null, suspended = false, relayThrough = null, id, protocol } = {}) {
     super({ suspended })
 
     this.serverKey = HypercoreId.decode(serverKey)

--- a/package.json
+++ b/package.json
@@ -27,16 +27,18 @@
   "devDependencies": {
     "b4a": "^1.6.7",
     "brittle": "^3.11.0",
+    "corestore": "^7.4.5",
     "hyperdht": "^6.20.1",
+    "hyperswarm": "^4.12.1",
     "standard": "^17.1.2"
   },
   "dependencies": {
     "compact-encoding": "^2.16.0",
     "hypercore-id-encoding": "^1.3.0",
     "protomux-rpc": "^1.7.1",
-    "suspend-resource": "^1.0.0",
     "resolve-reject-promise": "^1.1.0",
     "safety-catch": "^1.0.2",
-    "signal-promise": "^1.0.3"
+    "signal-promise": "^1.0.3",
+    "suspend-resource": "^1.0.0"
   }
 }

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -249,7 +249,7 @@ test('keyPair opt', async t => {
 
     const rpc = new ProtomuxRPC(c, {
       id: serverPubKey,
-      valueEncoding: c.none
+      valueEncoding: cenc.none
     })
     rpc.respond(
       'echo',

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -391,7 +391,6 @@ async function setupRpcServer (t, bootstrap, { msDelay = 0, extraIds = [], extra
     )
 
     for (const id of extraIds) {
-      console.log('setting up id', id)
       const rpcI = new ProtomuxRPC(conn, {
         id,
         valueEncoding: cenc.none

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -4,6 +4,8 @@ const cenc = require('compact-encoding')
 const HyperDHT = require('hyperdht')
 const getTestnet = require('hyperdht/testnet')
 const b4a = require('b4a')
+const Corestore = require('corestore')
+const Hyperswarm = require('hyperswarm')
 
 const ProtomuxRpcClient = require('../lib/client')
 
@@ -56,7 +58,7 @@ test('client can use keyPair opt', async t => {
 
     const rpc = new ProtomuxRPC(c, {
       id: serverPubKey,
-      valueEncoding: c.none
+      valueEncoding: cenc.none
     })
     rpc.respond(
       'echo',
@@ -174,6 +176,111 @@ test('request resolves without return value if closed while suspended', async t 
   await t.execution(async () => await p, 'no error on uncompleted request when closing')
 })
 
+test('can open rpcs with different id to same server', async t => {
+  const bootstrap = await getBootstrap(t)
+  const extraIds = [b4a.from('1')]
+  const { serverPubKey } = await getServer(t, bootstrap, { extraIds })
+  const client = await getClient(t, bootstrap, serverPubKey)
+  const client2 = await getClient(t, bootstrap, serverPubKey, { id: extraIds[0] })
+
+  {
+    const r1 = await client.echo('ok')
+    const r2 = await client2.echo('ok')
+    t.is(r1, 'ok', 'sanity check')
+    t.is(r2, 'Id: 1 res: ok', 'sanity check')
+  }
+
+  await client.close()
+  t.is(client.rpc.closed, true, 'sanity check')
+
+  {
+    const r2 = await client2.echo('ok still')
+    t.is(r2, 'Id: 1 res: ok still', 'can still query r2')
+  }
+})
+
+test('can open rpcs with different protocol to same server', async t => {
+  const bootstrap = await getBootstrap(t)
+  const { serverPubKey } = await getServer(t, bootstrap, { extraProtocols: ['extra-protocol'] })
+  const client = await getClient(t, bootstrap, serverPubKey)
+  const client2 = await getClient(t, bootstrap, serverPubKey, { protocol: 'extra-protocol' })
+
+  {
+    const r1 = await client.echo('ok')
+    const r2 = await client2.echo('ok')
+    t.is(r1, 'ok', 'sanity check')
+    t.is(r2, 'Protocol: extra-protocol res: ok', 'uses RPC of other protocol')
+  }
+
+  await client.close()
+  t.is(client.rpc.closed, true, 'sanity check')
+
+  {
+    const r2 = await client2.echo('ok still')
+    t.is(r2, 'Protocol: extra-protocol res: ok still', 'can still query r2')
+  }
+})
+
+test('no interactions if also replicating a corestore with the server peer', async t => {
+  const bootstrap = await getBootstrap(t)
+  const store = new Corestore(await t.tmp())
+  const serverSwarm = new Hyperswarm({ bootstrap })
+
+  const core = store.get({ name: 'core' })
+  await core.append('block0')
+
+  serverSwarm.on('connection', c => {
+    if (DEBUG) console.log('(DEBUG) server opened connection')
+    if (DEBUG) c.on('close', '(DEBUG) server connection closed')
+    store.replicate(c)
+
+    const rpc = new ProtomuxRPC(c, {
+      id: serverPubKey,
+      valueEncoding: cenc.none
+    })
+    rpc.respond(
+      'echo',
+      { requestEncoding: cenc.string, responseEncoding: cenc.string },
+      async (req) => req
+    )
+  })
+  await serverSwarm.listen()
+  serverSwarm.join(core.discoveryKey)
+  await new Promise(resolve => setTimeout(resolve, 500)) // TODO: should be a flush
+
+  const serverPubKey = serverSwarm.keyPair.publicKey
+
+  const clientStore = new Corestore(await t.tmp())
+  const clientSwarm = new Hyperswarm({ bootstrap })
+  clientSwarm.on('connection', c => {
+    if (DEBUG) console.log('(DEBUG) client opened connection')
+    if (DEBUG) c.on('close', '(DEBUG) client connection closed')
+
+    clientStore.replicate(c)
+  })
+  const client = new EchoClient(serverPubKey, clientSwarm.dht, { backoffValues: [5000, 15000, 60000, 300000] })
+
+  const clientCore = clientStore.get(core.key)
+  await clientCore.ready()
+  clientSwarm.join(clientCore.discoveryKey)
+  const block0 = await core.get(0)
+  t.is(b4a.toString(block0), 'block0', 'sanity check')
+
+  const res = await client.echo('ok')
+  t.is(res, 'ok', 'sanity check')
+  await client.close()
+  t.is(client.rpc.closed, true, 'sanity checked')
+
+  await core.append('block1')
+  const block1 = await clientCore.get(1)
+  t.is(b4a.toString(block1), 'block1', 'corestore replication not stopped when rpc connection closes')
+
+  await clientSwarm.destroy()
+  await clientStore.close()
+  await serverSwarm.destroy()
+  await store.close()
+})
+
 async function getBootstrap (t) {
   const testnet = await getTestnet()
   const { bootstrap } = testnet
@@ -188,7 +295,7 @@ async function getBootstrap (t) {
   return bootstrap
 }
 
-async function getServer (t, bootstrap, { delay = null } = {}) {
+async function getServer (t, bootstrap, { delay = null, extraIds = [], extraProtocols = [] } = {}) {
   const serverDht = new HyperDHT({ bootstrap })
   const server = serverDht.createServer()
   await server.listen()
@@ -198,7 +305,7 @@ async function getServer (t, bootstrap, { delay = null } = {}) {
     if (DEBUG) console.log('(DEBUG) server opened connection')
     const rpc = new ProtomuxRPC(c, {
       id: serverPubKey,
-      valueEncoding: c.none
+      valueEncoding: cenc.none
     })
     rpc.respond(
       'echo',
@@ -208,6 +315,37 @@ async function getServer (t, bootstrap, { delay = null } = {}) {
         return req
       }
     )
+
+    for (const id of extraIds) {
+      const rpcI = new ProtomuxRPC(c, {
+        id,
+        valueEncoding: cenc.none
+      })
+      rpcI.respond(
+        'echo',
+        { requestEncoding: cenc.string, responseEncoding: cenc.string },
+        async (req) => {
+          if (delay) await new Promise(resolve => setTimeout(resolve, delay))
+          return `Id: ${id} res: ${req}`
+        }
+      )
+    }
+
+    for (const protocol of extraProtocols) {
+      const rpcI = new ProtomuxRPC(c, {
+        id: serverPubKey,
+        protocol,
+        valueEncoding: cenc.none
+      })
+      rpcI.respond(
+        'echo',
+        { requestEncoding: cenc.string, responseEncoding: cenc.string },
+        async (req) => {
+          if (delay) await new Promise(resolve => setTimeout(resolve, delay))
+          return `Protocol: ${protocol} res: ${req}`
+        }
+      )
+    }
   })
 
   t.teardown(async () => {
@@ -217,9 +355,9 @@ async function getServer (t, bootstrap, { delay = null } = {}) {
   return { server, serverDht, serverPubKey }
 }
 
-async function getClient (t, bootstrap, serverPubKey, { relayThrough, accessKeyPair, suspended } = {}) {
+async function getClient (t, bootstrap, serverPubKey, { id, relayThrough, accessKeyPair, suspended, protocol } = {}) {
   const dht = new HyperDHT({ bootstrap })
-  const client = new EchoClient(serverPubKey, dht, { keyPair: accessKeyPair, relayThrough, suspended, backoffValues: [5000, 15000, 60000, 300000] })
+  const client = new EchoClient(serverPubKey, dht, { id, keyPair: accessKeyPair, protocol, relayThrough, suspended, backoffValues: [5000, 15000, 60000, 300000] })
 
   t.teardown(async () => {
     await client.close()


### PR DESCRIPTION
Up till now we were assuming protomux's default protocol ('protomux-rpc') and the server's public key as id. This PR exposes using other id's and protocols.

To avoid making this a breaking change, I've kept the server's public key as the default id, but note that this is NOT the protomux-rpc default (this was an oversight in the initial version of this module).

