### PR TITLE
Bugfix: no connection opened when suspending before establishing a connection

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -85,7 +85,7 @@ class ProtomuxRpcConnection extends SuspendResource {
 
     this._backoff.reset()
 
-    while (!this.closing && !this.suspended) {
+    while (!this.closing && !this.suspended && !this.shouldBeSuspended) {
       if (this.dht.destroyed) return
 
       const socket = this.dht.connect(this.serverKey, { keyPair: this.keyPair, relayThrough: this.relayThrough })
@@ -120,7 +120,7 @@ class ProtomuxRpcConnection extends SuspendResource {
       }
     }
 
-    if (this.closing || this.suspended) return
+    if (this.closing || this.suspended || this.shouldBeSuspended) return
 
     const socket = this.rpc.stream
     socket.once('close', () => this.connect().catch(safetyCatch))
@@ -164,7 +164,6 @@ class ProtomuxRpcConnection extends SuspendResource {
     }
 
     if (this.closing) return
-
     return await this.rpc.request(
       methodName,
       args,

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -159,6 +159,16 @@ test('start suspended flow', async t => {
   t.is(res, 'ok', 'correct response (sanity check)')
 })
 
+test('no connection opened when suspending before connecting', async t => {
+  const bootstrap = await getBootstrap(t)
+  const { serverPubKey } = await getServer(t, bootstrap)
+  const client = await getClient(t, bootstrap, serverPubKey)
+
+  t.is(client.rpc, null, 'sanity check: no rpc setup yet')
+  await client.suspend()
+  t.is(client.rpc, null, 'still no rpc setup after suspending')
+})
+
 test('request resolves without return value if closed while suspended', async t => {
   const bootstrap = await getBootstrap(t)
   const { serverPubKey } = await getServer(t, bootstrap)


### PR DESCRIPTION
Previous behaviour would open a connection while flushing `connect` during `suspend`