### PR TITLE
Reject request if we close before it gets launched

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -163,7 +163,8 @@ class ProtomuxRpcConnection extends SuspendResource {
       }
     }
 
-    if (this.closing) return
+    if (this.closing) throw Errors.CLIENT_CLOSING()
+
     return await this.rpc.request(
       methodName,
       args,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -15,6 +15,10 @@ class ProtomuxRpcClientError extends Error {
   static REQUEST_TIMEOUT () {
     return new ProtomuxRpcClientError('The request timed out', 'REQUEST_TIMEOUT', ProtomuxRpcClientError.REQUEST_TIMEOUT)
   }
+
+  static CLIENT_CLOSING () {
+    return new ProtomuxRpcClientError('The protomux-rpc client is closing', 'CLIENT_CLOSING', ProtomuxRpcClientError.CLIENT_CLOSING)
+  }
 }
 
 module.exports = ProtomuxRpcClientError

--- a/test/test-client.js
+++ b/test/test-client.js
@@ -169,7 +169,8 @@ test('no connection opened when suspending before connecting', async t => {
   t.is(client.rpc, null, 'still no rpc setup after suspending')
 })
 
-test('request resolves without return value if closed while suspended', async t => {
+test('request rejects if closed while suspended', async t => {
+  t.plan(1)
   const bootstrap = await getBootstrap(t)
   const { serverPubKey } = await getServer(t, bootstrap)
   const client = await getClient(t, bootstrap, serverPubKey)
@@ -177,13 +178,10 @@ test('request resolves without return value if closed while suspended', async t 
   await client.suspend()
   const p = client.echo('ok')
   p.catch(e => {
-    console.error(e)
-    t.fail('request should not error when closing')
+    t.is(e.code, 'CLIENT_CLOSING', 'pending request rejects if client closes')
   })
   await new Promise(resolve => setTimeout(resolve, 100))
   await client.close()
-
-  await t.execution(async () => await p, 'no error on uncompleted request when closing')
 })
 
 test('client can close also if it never connects', async t => {


### PR DESCRIPTION
Previous behaviour was to early-return (with `undefined` return value), which causes issues for upstream clients who expect a response