### PR TITLE
add protomux-rpc-client event method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ Options:
 }
 ```
 
+#### `client.event(key, methodName, args, opts)`
+
+Creates a fire-and-forget event call. The `key`, `methodName`, and `args` parameters follow the same contract as `client.makeRequest(...)`.
+
+Options:
+
+```
+{
+  requestEncoding, // Used to encode the `args`. Default: the protomux-rpc default.
+  id, // id of the protomux-rpc service
+  protocol // protocol of the protomux-rpc service. Defaults to the server's public key.
+}
+```
+
 #### `await client.suspend()`
 
 Suspends all open RPC clients, destroying their RPC channel.

--- a/index.js
+++ b/index.js
@@ -58,6 +58,9 @@ class ProtomuxRpcClient extends SuspendResource {
       requests: {
         sent: 0,
         success: 0
+      },
+      events: {
+        sent: 0
       }
     }
     this._clientRefs = new Map()
@@ -167,6 +170,21 @@ class ProtomuxRpcClient extends SuspendResource {
     } finally {
       ref.unref()
     }
+  }
+
+  async _event(key, methodName, args, { requestEncoding, protocol, id }) {
+    if (!this.opened) await this.ready()
+
+    const ref = this._getClient(key, protocol, id)
+    try {
+      await ref.client.event(methodName, args, { requestEncoding })
+    } finally {
+      ref.unref()
+    }
+  }
+
+  event(key, methodName, args, { requestEncoding, protocol, id } = {}) {
+    this._event(key, methodName, args, { requestEncoding, protocol, id }).catch(safetyCatch)
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -42,6 +42,9 @@ class ProtomuxRpcConnection extends SuspendResource {
       requests: {
         sent: 0,
         success: 0
+      },
+      events: {
+        sent: 0
       }
     }
 
@@ -218,6 +221,33 @@ class ProtomuxRpcConnection extends SuspendResource {
     }
   }
 
+  async event(methodName, args, { requestEncoding, timeout = 10000 } = {}) {
+    if (!this.opened) await this.ready()
+
+    // DEVNOTE: there is no need to track timers at object level (to clear them on close):
+    // closing causes the RPC clients to close, causing the event to reject
+    // which triggers the finally that clears the timeout
+    const timeoutSignal = new Signal()
+    const timer = setTimeout(() => {
+      timeoutSignal.notify(Errors.REQUEST_TIMEOUT())
+    }, timeout)
+    const abortSignalPromise = timeoutSignal.wait()
+    abortSignalPromise.catch(safetyCatch)
+
+    try {
+      return await this._requestConcurrentLimiter.execute(
+        async () => {
+          await this._connectAndWaitForReadyRpc({ abortSignalPromise })
+          this.stats.events.sent++
+          this.rpc.event(methodName, args, { requestEncoding })
+        },
+        { abortSignalPromise }
+      )
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
   // this maybe can be abstracted to SuspendResource
   async _waitUntilNotSuspended() {
     while (this.suspended && !this.closing) {
@@ -226,20 +256,22 @@ class ProtomuxRpcConnection extends SuspendResource {
     }
   }
 
+  async _connectAndWaitForReadyRpc({ abortSignalPromise }) {
+    while ((!this.rpc || this.rpc.closed) && !this.closing) {
+      await Promise.race([this.connect(), abortSignalPromise])
+      await Promise.race([this._waitUntilNotSuspended(), abortSignalPromise])
+    }
+
+    if (this.closing) throw Errors.CLIENT_CLOSING()
+  }
+
   async _connectAndSendRequest(
     methodName,
     args,
     { requestEncoding, responseEncoding, rpcTimeout, abortSignalPromise }
   ) {
     const expectedTimeLimit = Date.now() + rpcTimeout
-
-    while ((!this.rpc || this.rpc.closed) && !this.closing) {
-      await Promise.race([this.connect(), abortSignalPromise])
-
-      await Promise.race([this._waitUntilNotSuspended(), abortSignalPromise])
-    }
-
-    if (this.closing) throw Errors.CLIENT_CLOSING()
+    await this._connectAndWaitForReadyRpc({ abortSignalPromise })
 
     const expectedRpcTimeout = expectedTimeLimit - Date.now()
     if (expectedRpcTimeout <= 0) {

--- a/test/test-basic.js
+++ b/test/test-basic.js
@@ -44,6 +44,46 @@ test('stateless RPC connection lifecycle', async (t) => {
   t.is(statelessRpc.nrConnections, 0, 'cleaned up clients')
 })
 
+test('event method', async (t) => {
+  t.plan(3)
+
+  const bootstrap = await setupTestnet(t)
+
+  const serverDht = new HyperDHT({ bootstrap })
+  const server = serverDht.createServer()
+  await server.listen()
+  const { publicKey: serverPubKey } = server.address()
+
+  t.teardown(async () => {
+    await serverDht.destroy()
+  })
+
+  let rpcClient = null
+  server.on('connection', (conn) => {
+    const rpc = new ProtomuxRPC(conn, {
+      id: serverPubKey,
+      valueEncoding: cenc.none
+    })
+    rpc.respond('greet', { requestEncoding: cenc.string }, (req) => {
+      t.is(req, 'hi')
+      t.is(rpcClient.stats.events.sent, 1, 'event stats sent incremented')
+      t.is(rpcClient.stats.requests.sent, 0, 'event does not affect request stats')
+    })
+  })
+
+  const clientDht = new HyperDHT({ bootstrap })
+  rpcClient = new ProtomuxRpcClient(clientDht)
+
+  t.teardown(async () => {
+    await rpcClient.close()
+    await clientDht.destroy()
+  })
+
+  rpcClient.event(serverPubKey, 'greet', 'hi', {
+    requestEncoding: cenc.string
+  })
+})
+
 test('stateless RPC no cleanup if active requests', async (t) => {
   const bootstrap = await setupTestnet(t)
   const { server, getNrCons } = await setupRpcServer(t, bootstrap, { msDelay: 1000 })


### PR DESCRIPTION
The PR is part of a larger update to support the event method, along with the following related changes:

- Merge https://github.com/holepunchto/bucket-rate-limit/pull/4 to expose tryAcquire as a public API.
- In `protomux-rpc-client-pool`, expose a non-async event method that shares the same rate limiter with `makeRequest`, but instead of waiting for a token, it uses `tryAcquire` and discards the event if no token is available. The event method also does not perform retries